### PR TITLE
Implement LLVM Type and Value Representations

### DIFF
--- a/compiler/tahuc_codegen_llvm/Cargo.toml
+++ b/compiler/tahuc_codegen_llvm/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "tahuc_codegen_llvm"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+tahuc_span = { path = "../tahuc_span" }
+tahuc_ast = { path = "../tahuc_ast" }
+tahuc_hir = { path = "../tahuc_hir" }
+tahuc_mir = { path = "../tahuc_mir" }
+tahuc_llvm = { path = "../tahuc_llvm" }

--- a/compiler/tahuc_codegen_llvm/src/codegen.rs
+++ b/compiler/tahuc_codegen_llvm/src/codegen.rs
@@ -1,0 +1,177 @@
+use std::{collections::HashMap, process::exit};
+
+use tahuc_hir::hir::FunctionId;
+use tahuc_mir::mir::{
+    BasicBlockId, GlobalId, LocalId, MirModule, instruction::MirOperand, ty::MirConstant,
+};
+use tahuc_span::FileId;
+
+use crate::llvm::{
+    BasicBlock, BasicValue, Builder, CodeModel, Context, FileType, FunctionValue, Module, OptLevel,
+    PointerValue, RelocMode, StructType, Target, TargetTriple, Type,
+};
+
+pub struct Codegen {
+    // llvm
+    pub(crate) context: Context,
+    pub(crate) module: Module,
+    pub(crate) builder: Builder,
+
+    // current file id
+    pub(crate) file_id: FileId,
+
+    // mapping function
+    pub(crate) functions_map: HashMap<FunctionId, FunctionValue>,
+
+    // mapping for current function
+    pub(crate) basic_blocks_map: HashMap<BasicBlockId, BasicBlock>,
+    pub(crate) ptr_map: HashMap<LocalId, PointerValue>,
+    pub(crate) value_map: HashMap<LocalId, BasicValue>,
+
+    pub(crate) struct_types: HashMap<String, StructType>,
+    pub(crate) global_types: HashMap<GlobalId, Type>,
+}
+
+impl Codegen {
+    pub fn new(context: Context, name: String) -> Self {
+        let builder = context.create_builder();
+        let module = context.create_module(&name);
+
+        Self {
+            context,
+            module,
+            builder,
+
+            file_id: FileId(0),
+
+            functions_map: HashMap::new(),
+
+            basic_blocks_map: HashMap::new(),
+            ptr_map: HashMap::new(),
+            value_map: HashMap::new(),
+
+            struct_types: HashMap::new(),
+            global_types: HashMap::new(),
+        }
+    }
+
+    pub fn context() -> Context {
+        Context::create()
+    }
+
+    pub fn compile_module(&mut self, module: &MirModule) {
+        self.file_id = module.file_id;
+
+        for (id, ty) in &module.globals {
+            let ty = self.ty_to_llvm(ty);
+            self.global_types.insert(*id, ty);
+        }
+
+        for function in &module.extern_functions {
+            self.declare_extern_function(function);
+        }
+
+        for function in &module.functions {
+            self.declare_function(function);
+        }
+
+        for function in &module.functions {
+            self.compile_function(function);
+        }
+    }
+
+    pub(crate) fn operand_ptr(&self, operand: &MirOperand) -> Result<PointerValue, String> {
+        match operand {
+            MirOperand::Local(id) => self
+                .ptr_map
+                .get(id)
+                .copied()
+                .ok_or_else(|| format!("Local ptr {} not found", id)),
+            MirOperand::Constant(c) => {
+                Err(format!("Constant cannot to pointer {} {:?}", c, operand))
+            }
+        }
+    }
+
+    pub(crate) fn operand_value(&self, operand: &MirOperand) -> Result<BasicValue, String> {
+        match operand {
+            MirOperand::Local(id) => self
+                .value_map
+                .get(id)
+                .copied()
+                .ok_or_else(|| format!("Local value {} not found", id)),
+            MirOperand::Constant(c) => Ok(self.compile_constant(c)),
+        }
+    }
+
+    pub(crate) fn compile_constant(&self, constant: &MirConstant) -> BasicValue {
+        match constant {
+            MirConstant::Int { value, ty } => {
+                let ty = self.int_ty(ty);
+                let value = ty.const_int(*value as u64, true);
+                value.into()
+            }
+            MirConstant::Float { value, ty } => {
+                let ty = self.float_ty(ty);
+                let value = ty.const_float(*value as f64);
+                value.into()
+            }
+            MirConstant::Bool(b) => self.context.bool_ty().const_bool(*b as u64, false).into(),
+            MirConstant::Null(_) => self.context.ptr_ty().const_null().into(),
+            MirConstant::Char(c) => self.context.i8_ty().const_int(*c as u64, false).into(),
+            MirConstant::String(s) => {
+                let value = self.context.const_string(s.as_bytes(), false);
+                let global_string = self
+                    .module
+                    .add_global(value.get_type(), &format!("str_{}", self.file_id.0));
+                global_string.set_initializer(value.into());
+                global_string.as_ptr().into()
+            }
+        }
+    }
+
+    pub(crate) fn add_value(&mut self, target: LocalId, value: BasicValue) {
+        if value.is_pointer_value() {
+            self.ptr_map.insert(target, value.into_ptr_value());
+        }
+        self.value_map.insert(target, value);
+    }
+
+    pub(crate) fn add_ptr(&mut self, target: LocalId, ptr: PointerValue) {
+        self.ptr_map.insert(target, ptr);
+        self.value_map.insert(target, ptr.into());
+    }
+
+    pub fn verify(&self) {
+        let res = self.module.verify();
+        if let Err(_) = res {
+            exit(1);
+        }
+    }
+
+    pub fn to_string(&self) -> String {
+        self.module.print_to_string()
+    }
+
+    pub fn write_object_file(&self, path: &str) {
+        Target::init_x86();
+
+        let triple = TargetTriple::default();
+        let target = Target::from_triple(triple);
+
+        let machine = target.create_target_machine(
+            triple,
+            "",
+            "",
+            OptLevel::Aggressive,
+            RelocMode::Default,
+            CodeModel::Default,
+        );
+
+        let result = machine.emit_to_file(self.module, path, FileType::Object);
+
+        if let Err(s) = result {
+            panic!("failed to write object file {}", s);
+        }
+    }
+}

--- a/compiler/tahuc_codegen_llvm/src/function.rs
+++ b/compiler/tahuc_codegen_llvm/src/function.rs
@@ -1,0 +1,65 @@
+use tahuc_mir::mir::function::{MirExternFunction, MirFunction};
+
+use crate::codegen::Codegen;
+
+impl Codegen {
+    pub(crate) fn declare_extern_function(&mut self, function: &MirExternFunction) {
+        let ty = self.ty_to_llvm(&function.return_type);
+        let params = function
+            .parameters
+            .iter()
+            .map(|p| self.ty_to_llvm(&p))
+            .collect::<Vec<_>>();
+
+        let func_ty = ty.fn_ty(params.as_slice(), false);
+
+        let func = self.module.add_function(&function.name, func_ty);
+        self.functions_map.insert(function.id, func);
+    }
+
+    pub(crate) fn declare_function(&mut self, function: &MirFunction) {
+        let ty = self.ty_to_llvm(&function.return_type);
+        let params = function
+            .parameters
+            .iter()
+            .map(|p| self.ty_to_llvm(&p.ty))
+            .collect::<Vec<_>>();
+
+        let func_ty = ty.fn_ty(params.as_slice(), false);
+
+        let func = self.module.add_function(&function.name, func_ty);
+        self.functions_map.insert(function.id, func);
+    }
+
+    fn reset_state(&mut self) {
+        self.basic_blocks_map.clear();
+        self.ptr_map.clear();
+        self.value_map.clear();
+    }
+
+    pub(crate) fn compile_function(&mut self, function: &MirFunction) {
+        self.reset_state();
+
+        let func = self.functions_map[&function.id];
+
+        for id in &function.block_order {
+            let block = function.get_block(*id).unwrap();
+            let bb = self.context.append_basic_block(func, &block.name);
+            self.basic_blocks_map.insert(block.id, bb);
+        }
+
+        let entry = self.basic_blocks_map.get(&function.entry_block).unwrap();
+        self.builder.position_at_end(*entry);
+
+        for (i, param) in function.parameters.iter().enumerate() {
+            let id = param.id;
+            let value = func.get_param_at(i);
+            self.add_value(id, value);
+        }
+
+        for id in &function.block_order {
+            let block = function.get_block(*id).unwrap();
+            self.compile_basic_block(block);
+        }
+    }
+}

--- a/compiler/tahuc_codegen_llvm/src/instruction.rs
+++ b/compiler/tahuc_codegen_llvm/src/instruction.rs
@@ -1,0 +1,420 @@
+use core::panic;
+
+use tahuc_ast::nodes::op::{BinaryOp, UnaryOp};
+use tahuc_mir::mir::{
+    block::{MirBasicBlock, MirTerminator},
+    instruction::{CastKind, MirInstruction, MirOperand},
+    ty::{MirType, MirTypeKind},
+};
+
+use crate::{
+    codegen::Codegen,
+    llvm::{BasicBlock, BasicValue, FloatValue, IntType, IntValue, LLVMCastKind},
+};
+
+impl Codegen {
+    pub(crate) fn compile_basic_block(&mut self, block: &MirBasicBlock) {
+        let bb = self.basic_blocks_map[&block.id];
+        self.builder.position_at_end(bb);
+
+        for instruction in &block.instructions {
+            self.compile_instruction(instruction);
+        }
+
+        self.compile_terminator(&block.terminator);
+    }
+
+    pub(crate) fn compile_instruction(&mut self, instruction: &MirInstruction) {
+        match &instruction {
+            MirInstruction::Alloca { target, ty } => {
+                let ty = self.ty_to_llvm(ty);
+                let ptr = self.builder.alloca(ty);
+
+                self.add_ptr(*target, ptr);
+            }
+            MirInstruction::Load { target, ptr, ty } => {
+                let ty = self.ty_to_llvm(ty);
+                let ptr = self.operand_ptr(ptr).unwrap();
+                let value = self.builder.load(ty, ptr);
+
+                self.add_value(*target, value);
+            }
+            MirInstruction::Store { ptr, value, .. } => {
+                let ptr = self.operand_ptr(ptr).unwrap();
+                let value = self.operand_value(value).unwrap();
+
+                self.builder.store(ptr, value);
+            }
+            MirInstruction::GetElementPtr {
+                target,
+                base,
+                indices,
+                inner_ty,
+                ..
+            } => {
+                let ty = self.ty_to_llvm(inner_ty);
+                let ptr = self.operand_ptr(base).unwrap();
+                let binding: Result<Vec<IntValue>, _> = indices
+                    .iter()
+                    .map(|val| self.operand_value(val).map(|a| a.into_int_value()))
+                    .collect();
+                let indices = binding.unwrap();
+
+                let result = self.builder.gep(ty, ptr, indices.as_slice());
+
+                self.add_ptr(*target, result);
+            }
+            MirInstruction::Binary {
+                target,
+                left,
+                op,
+                right,
+                ty,
+            } => {
+                let left_val = self.operand_value(left).unwrap();
+                let right_val = self.operand_value(right).unwrap();
+
+                let value = self.build_binary_op(op, left_val, right_val, ty).unwrap();
+
+                self.add_value(*target, value);
+            }
+            MirInstruction::Unary {
+                target,
+                op,
+                value,
+                ty,
+            } => {
+                let value = self.build_unary(op, value, ty);
+
+                self.add_value(*target, value);
+            }
+            MirInstruction::Call {
+                target,
+                function,
+                arguments,
+                ..
+            } => {
+                let func = self.functions_map[function];
+
+                let args = arguments
+                    .iter()
+                    .map(|arg| self.operand_value(arg).unwrap())
+                    .collect::<Vec<_>>();
+
+                let call_result = self.builder.call(func, &args);
+
+                if !call_result.is_void() {
+                    let value = BasicValue::new(call_result);
+                    self.add_value(*target, value);
+                }
+            }
+            MirInstruction::Phi { target, values, ty } => {
+                let ty = self.ty_to_llvm(ty);
+                let mut phi = self.builder.phi(ty);
+
+                let incomings: Vec<(BasicValue, BasicBlock)> = values
+                    .iter()
+                    .map(|(v, bb)| (self.operand_value(v).unwrap(), self.basic_blocks_map[bb]))
+                    .collect();
+
+                phi.add_incoming(incomings);
+
+                let basic_value = BasicValue::new(phi.as_value());
+
+                self.add_value(*target,basic_value);
+            }
+            MirInstruction::Select {
+                target,
+                condition,
+                then_branch,
+                else_branch,
+            } => {
+                let cond = self.operand_value(condition).unwrap();
+                let then = self.operand_value(then_branch).unwrap();
+                let else_branch = self.operand_value(else_branch).unwrap();
+
+                let value = self.builder.select(cond, then, else_branch);
+
+                self.add_value(*target, value);
+            }
+            MirInstruction::Cast {
+                target,
+                kind,
+                value,
+                to,
+                ..
+            } => {
+                let op = self.cast_op_to_llvm(kind);
+                let value = self.operand_value(value).unwrap();
+                let to = self.ty_to_llvm(to);
+
+                let value = self.builder.cast(op, value, to);
+
+                self.add_value(*target, value);
+            }
+        }
+    }
+
+    fn cast_op_to_llvm(&self, op: &CastKind) -> LLVMCastKind {
+        match op {
+            CastKind::Trunc => LLVMCastKind::Trunc,
+            CastKind::ZExt => LLVMCastKind::ZExt,
+            CastKind::SExt => LLVMCastKind::SExt,
+            CastKind::FPToUI => LLVMCastKind::FPToUI,
+            CastKind::FPToSI => LLVMCastKind::FPToSI,
+            CastKind::UIToFP => LLVMCastKind::UIToFP,
+            CastKind::SIToFP => LLVMCastKind::SIToFP,
+            CastKind::PtrToInt => LLVMCastKind::PtrToInt,
+            CastKind::IntToPtr => LLVMCastKind::IntToPtr,
+            CastKind::BitCast => LLVMCastKind::BitCast,
+            CastKind::NoOp => panic!("NoOp cast should not generate code"),
+        }
+    }
+
+    pub(crate) fn compile_terminator(&mut self, terminator: &MirTerminator) {
+        match terminator {
+            MirTerminator::Return { value } => {
+                if let Some(value) = value {
+                    let value = self.operand_value(value).unwrap();
+                    self.builder.ret(value);
+                } else {
+                    self.builder.ret_void();
+                }
+            }
+            MirTerminator::Jump { target } => {
+                let block = self.basic_blocks_map[target];
+                self.builder.jump(block);
+            }
+            MirTerminator::Branch {
+                condition,
+                true_target,
+                false_target,
+            } => {
+                let condition = self.operand_value(condition).unwrap();
+                let then_branch = self.basic_blocks_map[true_target];
+                let else_branch = self.basic_blocks_map[false_target];
+
+                self.builder.branch(condition, then_branch, else_branch);
+            }
+            MirTerminator::Unreachable => {
+                self.builder.unreachable();
+            }
+        }
+    }
+
+    fn build_binary_op(
+        &mut self,
+        op: &BinaryOp,
+        left: BasicValue,
+        right: BasicValue,
+        ty: &MirType,
+    ) -> Result<BasicValue, String> {
+        match ty.kind() {
+            MirTypeKind::SignedInt => {
+                let result =
+                    self.build_int_bin_op(op, left.into_int_value(), right.into_int_value(), true);
+                Ok(result.into())
+            }
+            MirTypeKind::UnsignedInt => {
+                let result =
+                    self.build_int_bin_op(op, left.into_int_value(), right.into_int_value(), false);
+                Ok(result.into())
+            }
+            MirTypeKind::Float => {
+                let result =
+                    self.build_float_bin_op(op, left.into_float_value(), right.into_float_value());
+                Ok(result.into())
+            }
+            MirTypeKind::Bool => {
+                // boolean ops: And/Or
+                match op {
+                    BinaryOp::Eq
+                    | BinaryOp::Ne
+                    | BinaryOp::Lt
+                    | BinaryOp::Le
+                    | BinaryOp::Gt
+                    | BinaryOp::Ge => {
+                        match ty.kind() {
+                            MirTypeKind::Bool => {
+                                // hasilnya bool, tapi operandnya numeric
+                                if left.is_int_value() {
+                                    let lhs = left.into_int_value();
+                                    let rhs = right.into_int_value();
+                                    let res = self.build_int_bin_op(op, lhs, rhs, true); // or false for unsigned
+                                    Ok(res.into())
+                                } else if left.is_float_value() {
+                                    let lhs = left.into_float_value();
+                                    let rhs = right.into_float_value();
+                                    let res = self.build_float_cmp(op, lhs, rhs); // kamu bikin helper khusus float cmp
+                                    Ok(res.into())
+                                } else {
+                                    Err("Invalid operand type for comparison".to_string())
+                                }
+                            }
+                            _ => Err("Comparison must return bool".to_string()),
+                        }
+                    }
+                    BinaryOp::And => {
+                        let result = self
+                            .builder
+                            .and(left.into_int_value(), right.into_int_value());
+                        Ok(result.into())
+                    }
+                    BinaryOp::Or => {
+                        let result = self
+                            .builder
+                            .or(left.into_int_value(), right.into_int_value());
+                        Ok(result.into())
+                    }
+                    // comparison: reuse signed int predicates
+                    _ => {
+                        let target_ty = self.ty_to_llvm(ty);
+                        let left_val = left.into_int_value();
+                        let right_val = right.into_int_value();
+
+                        let left = self.cast_int_to(left_val, target_ty.into_int_ty(), true)?;
+                        let right = self.cast_int_to(right_val, target_ty.into_int_ty(), true)?;
+                        let result = self.build_int_bin_op(
+                            op,
+                            left.into_int_value(),
+                            right.into_int_value(),
+                            false,
+                        );
+                        Ok(result.into())
+                    }
+                }
+                // match op {
+                //     // Ok(self.build_int_bin_op(&self.builder, op, left.into_int_value(), right.into_int_value(), false).into()),
+                // }
+            }
+            _ => Err(format!(
+                "Unsupported binary operation {:?} for type {:?}",
+                op, ty
+            )),
+        }
+    }
+
+    fn build_int_bin_op(
+        &mut self,
+        op: &BinaryOp,
+        left: IntValue,
+        right: IntValue,
+        signed: bool,
+    ) -> IntValue {
+        use BinaryOp::*;
+        match op {
+            Add => self.builder.i_add(left, right),
+            Sub => self.builder.i_sub(left, right),
+            Mul => self.builder.i_mul(left, right),
+            Div => self.builder.i_div(left, right, signed),
+            Rem => self.builder.i_rem(left, right, signed),
+            Eq => self.builder.i_eq(left, right),
+            Ne => self.builder.i_ne(left, right),
+            Lt => self.builder.i_lt(left, right, signed),
+            Le => self.builder.i_le(left, right, signed),
+            Gt => self.builder.i_gt(left, right, signed),
+            Ge => self.builder.i_ge(left, right, signed),
+            Shl => self.builder.i_shl(left, right),
+            Shr => self.builder.i_shr(left, right, signed),
+            BitAnd => self.builder.and(left, right),
+            _ => panic!("Unsupported int op {:?}", op),
+        }
+    }
+
+    fn build_float_bin_op(
+        &mut self,
+        op: &BinaryOp,
+        left: FloatValue,
+        right: FloatValue,
+    ) -> FloatValue {
+        use BinaryOp::*;
+        match op {
+            Add => self.builder.f_add(left, right),
+            Sub => self.builder.f_sub(left, right),
+            Mul => self.builder.f_mul(left, right),
+            Div => self.builder.f_div(left, right),
+            _ => panic!("Unsupported float op {:?}", op),
+        }
+    }
+
+    fn build_float_cmp(
+        &mut self,
+        op: &BinaryOp,
+        left: FloatValue,
+        right: FloatValue,
+    ) -> FloatValue {
+        use BinaryOp::*;
+        match op {
+            Eq => self.builder.f_eq(left, right),
+            Ne => self.builder.f_ne(left, right),
+            Lt => self.builder.f_lt(left, right),
+            Le => self.builder.f_le(left, right),
+            Gt => self.builder.f_gt(left, right),
+            Ge => self.builder.f_ge(left, right),
+            _ => panic!("Unsupported float comparison op {:?}", op),
+        }
+    }
+
+    fn cast_int_to(
+        &mut self,
+        val: IntValue,
+        target_ty: IntType,
+        signed: bool,
+    ) -> Result<BasicValue, String> {
+        let val_bits = val.get_ty().get_bit_width();
+        let target_bits = target_ty.get_bit_width();
+        let basic = BasicValue::new(val.as_value());
+        if val_bits < target_bits {
+            if signed {
+                let result = self
+                    .builder
+                    .cast(LLVMCastKind::SExt, basic, target_ty.as_ty());
+                Ok(result)
+            } else {
+                let result = self
+                    .builder
+                    .cast(LLVMCastKind::ZExt, basic, target_ty.as_ty());
+                Ok(result)
+            }
+        } else if val_bits > target_bits {
+            let result = self
+                .builder
+                .cast(LLVMCastKind::Trunc, basic, target_ty.as_ty());
+            Ok(result)
+        } else {
+            Ok(basic)
+        }
+    }
+
+    fn build_unary(&mut self, op: &UnaryOp, value: &MirOperand, ty: &MirType) -> BasicValue {
+        match op {
+            UnaryOp::Minus => {
+                let value = self.operand_value(value).unwrap();
+
+                let result = if ty.clone().is_integer() {
+                    let value = self
+                    .builder
+                    .i_neg(value.into_int_value());
+                    BasicValue::new(value.as_value())
+                } else if ty.clone().is_float() {
+                    let value = self
+                    .builder
+                    .f_neg(value.into_float_value());
+                    BasicValue::new(value.as_value())
+                } else {
+                    panic!("Unsupported unary operation {:?}", op)
+                };
+
+                result
+            }
+            UnaryOp::Not => {
+                let value = self.operand_value(value).unwrap();
+                let result = self
+                    .builder
+                    .i_not(value.into_int_value());
+                BasicValue::new(result.as_value())
+            }
+            _ => panic!("Unsupported unary operation {:?}", op),
+        }
+    }
+}

--- a/compiler/tahuc_codegen_llvm/src/lib.rs
+++ b/compiler/tahuc_codegen_llvm/src/lib.rs
@@ -1,0 +1,7 @@
+mod llvm;
+mod codegen;
+mod function;
+mod ty;
+mod instruction;
+
+pub use codegen::Codegen;

--- a/compiler/tahuc_codegen_llvm/src/llvm/basic_block.rs
+++ b/compiler/tahuc_codegen_llvm/src/llvm/basic_block.rs
@@ -1,0 +1,18 @@
+use tahuc_llvm::opaque::LLVMBasicBlockRef;
+
+#[derive(Debug, Clone, Copy)]
+pub struct BasicBlock {
+    block: LLVMBasicBlockRef
+}
+
+impl BasicBlock {
+    pub fn new(block: LLVMBasicBlockRef) -> Self {
+        Self {
+            block
+        }
+    }
+
+    pub fn as_block_ref(self) -> LLVMBasicBlockRef {
+        self.block
+    }
+}

--- a/compiler/tahuc_codegen_llvm/src/llvm/binary/float.rs
+++ b/compiler/tahuc_codegen_llvm/src/llvm/binary/float.rs
@@ -1,0 +1,118 @@
+use tahuc_llvm::{
+    LLVMRealPredicate,
+    core::{
+        LLVMBuildFAdd, LLVMBuildFCmp, LLVMBuildFDiv, LLVMBuildFMul, LLVMBuildFRem, LLVMBuildFSub,
+    },
+};
+
+use crate::llvm::{Builder, FloatValue, Values};
+
+impl Builder {
+    pub fn f_add(&mut self, lhs: FloatValue, rhs: FloatValue) -> FloatValue {
+        let value = Values::new(unsafe {
+            LLVMBuildFAdd(
+                self.builder(),
+                lhs.as_value_ref(),
+                rhs.as_value_ref(),
+                self.default_zero_name(),
+            )
+        });
+
+        FloatValue::new(value)
+    }
+
+    pub fn f_sub(&mut self, lhs: FloatValue, rhs: FloatValue) -> FloatValue {
+        let value = Values::new(unsafe {
+            LLVMBuildFSub(
+                self.builder(),
+                lhs.as_value_ref(),
+                rhs.as_value_ref(),
+                self.default_zero_name(),
+            )
+        });
+
+        FloatValue::new(value)
+    }
+
+    pub fn f_mul(&mut self, lhs: FloatValue, rhs: FloatValue) -> FloatValue {
+        let value = Values::new(unsafe {
+            LLVMBuildFMul(
+                self.builder(),
+                lhs.as_value_ref(),
+                rhs.as_value_ref(),
+                self.default_zero_name(),
+            )
+        });
+
+        FloatValue::new(value)
+    }
+
+    pub fn f_div(&mut self, lhs: FloatValue, rhs: FloatValue) -> FloatValue {
+        let value = Values::new(unsafe {
+            LLVMBuildFDiv(
+                self.builder(),
+                lhs.as_value_ref(),
+                rhs.as_value_ref(),
+                self.default_zero_name(),
+            )
+        });
+
+        FloatValue::new(value)
+    }
+
+    pub fn f_rem(&mut self, lhs: FloatValue, rhs: FloatValue) -> FloatValue {
+        let value = Values::new(unsafe {
+            LLVMBuildFRem(
+                self.builder(),
+                lhs.as_value_ref(),
+                rhs.as_value_ref(),
+                self.default_zero_name(),
+            )
+        });
+
+        FloatValue::new(value)
+    }
+
+    fn build_float_compare(
+        &mut self,
+        op: LLVMRealPredicate,
+        lhs: FloatValue,
+        rhs: FloatValue,
+    ) -> FloatValue {
+        let value = Values::new(unsafe {
+            LLVMBuildFCmp(
+                self.builder(),
+                op,
+                lhs.as_value_ref(),
+                rhs.as_value_ref(),
+                self.default_zero_name(),
+            )
+        });
+
+        FloatValue::new(value)
+    }
+
+    pub fn f_eq(&mut self, lhs: FloatValue, rhs: FloatValue) -> FloatValue {
+        self.build_float_compare(LLVMRealPredicate::LLVMRealOEQ, lhs, rhs)
+    }
+
+    pub fn f_ne(&mut self, lhs: FloatValue, rhs: FloatValue) -> FloatValue {
+        self.build_float_compare(LLVMRealPredicate::LLVMRealONE, lhs, rhs)
+    }
+
+    pub fn f_lt(&mut self, lhs: FloatValue, rhs: FloatValue) -> FloatValue {
+        self.build_float_compare(LLVMRealPredicate::LLVMRealOLT, lhs, rhs)
+    }
+
+    pub fn f_le(&mut self, lhs: FloatValue, rhs: FloatValue) -> FloatValue {
+        self.build_float_compare(LLVMRealPredicate::LLVMRealOLE, lhs, rhs)
+    }
+
+    pub fn f_gt(&mut self, lhs: FloatValue, rhs: FloatValue) -> FloatValue {
+        self.build_float_compare(LLVMRealPredicate::LLVMRealOGT, lhs, rhs)
+    }
+
+    pub fn f_ge(&mut self, lhs: FloatValue, rhs: FloatValue) -> FloatValue {
+        self.build_float_compare(LLVMRealPredicate::LLVMRealOGE, lhs, rhs)
+    }
+}

--- a/compiler/tahuc_codegen_llvm/src/llvm/binary/int.rs
+++ b/compiler/tahuc_codegen_llvm/src/llvm/binary/int.rs
@@ -1,0 +1,191 @@
+use tahuc_llvm::{
+    LLVMIntPredicate,
+    core::{
+        LLVMBuildAShr, LLVMBuildAdd, LLVMBuildExactSDiv, LLVMBuildICmp, LLVMBuildLShr,
+        LLVMBuildMul, LLVMBuildSDiv, LLVMBuildSRem, LLVMBuildShl, LLVMBuildSub, LLVMBuildURem,
+    },
+};
+
+use crate::llvm::{Builder, IntValue, Values};
+
+impl Builder {
+    /// int add
+    pub fn i_add(&mut self, lhs: IntValue, rhs: IntValue) -> IntValue {
+        let value = Values::new(unsafe {
+            LLVMBuildAdd(
+                self.builder(),
+                lhs.as_value_ref(),
+                rhs.as_value_ref(),
+                self.default_zero_name(),
+            )
+        });
+
+        IntValue::new(value)
+    }
+
+    pub fn i_sub(&mut self, lhs: IntValue, rhs: IntValue) -> IntValue {
+        let value = Values::new(unsafe {
+            LLVMBuildSub(
+                self.builder(),
+                lhs.as_value_ref(),
+                rhs.as_value_ref(),
+                self.default_zero_name(),
+            )
+        });
+
+        IntValue::new(value)
+    }
+
+    pub fn i_mul(&mut self, lhs: IntValue, rhs: IntValue) -> IntValue {
+        let value = Values::new(unsafe {
+            LLVMBuildMul(
+                self.builder(),
+                lhs.as_value_ref(),
+                rhs.as_value_ref(),
+                self.default_zero_name(),
+            )
+        });
+
+        IntValue::new(value)
+    }
+
+    // todo safe div
+    pub fn i_div(&mut self, lhs: IntValue, rhs: IntValue, is_signed: bool) -> IntValue {
+        // todo call safe_div
+        let value = Values::new(unsafe {
+            if is_signed {
+                LLVMBuildSDiv(
+                    self.builder(),
+                    lhs.as_value_ref(),
+                    rhs.as_value_ref(),
+                    self.default_zero_name(),
+                )
+            } else {
+                LLVMBuildExactSDiv(
+                    self.builder(),
+                    lhs.as_value_ref(),
+                    rhs.as_value_ref(),
+                    self.default_zero_name(),
+                )
+            }
+        });
+
+        IntValue::new(value)
+    }
+
+    pub fn i_rem(&mut self, lhs: IntValue, rhs: IntValue, is_signed: bool) -> IntValue {
+        let value = Values::new(unsafe {
+            if is_signed {
+                LLVMBuildSRem(
+                    self.builder(),
+                    lhs.as_value_ref(),
+                    rhs.as_value_ref(),
+                    self.default_zero_name(),
+                )
+            } else {
+                LLVMBuildURem(
+                    self.builder(),
+                    lhs.as_value_ref(),
+                    rhs.as_value_ref(),
+                    self.default_zero_name(),
+                )
+            }
+        });
+
+        IntValue::new(value)
+    }
+
+    fn build_icmp(
+        &mut self,
+        op: tahuc_llvm::LLVMIntPredicate,
+        lhs: IntValue,
+        rhs: IntValue,
+    ) -> IntValue {
+        let value = Values::new(unsafe {
+            LLVMBuildICmp(
+                self.builder(),
+                op,
+                lhs.as_value_ref(),
+                rhs.as_value_ref(),
+                self.default_zero_name(),
+            )
+        });
+
+        IntValue::new(value)
+    }
+
+    pub fn i_eq(&mut self, lhs: IntValue, rhs: IntValue) -> IntValue {
+        self.build_icmp(LLVMIntPredicate::LLVMIntEQ, lhs, rhs)
+    }
+
+    pub fn i_lt(&mut self, lhs: IntValue, rhs: IntValue, is_signed: bool) -> IntValue {
+        if is_signed {
+            self.build_icmp(LLVMIntPredicate::LLVMIntSLT, lhs, rhs)
+        } else {
+            self.build_icmp(LLVMIntPredicate::LLVMIntULT, lhs, rhs)
+        }
+    }
+
+    pub fn i_le(&mut self, lhs: IntValue, rhs: IntValue, is_signed: bool) -> IntValue {
+        if is_signed {
+            self.build_icmp(LLVMIntPredicate::LLVMIntSLE, lhs, rhs)
+        } else {
+            self.build_icmp(LLVMIntPredicate::LLVMIntULE, lhs, rhs)
+        }
+    }
+
+    pub fn i_ne(&mut self, lhs: IntValue, rhs: IntValue) -> IntValue {
+        self.build_icmp(LLVMIntPredicate::LLVMIntNE, lhs, rhs)
+    }
+
+    pub fn i_ge(&mut self, lhs: IntValue, rhs: IntValue, is_signed: bool) -> IntValue {
+        if is_signed {
+            self.build_icmp(LLVMIntPredicate::LLVMIntSGE, lhs, rhs)
+        } else {
+            self.build_icmp(LLVMIntPredicate::LLVMIntUGE, lhs, rhs)
+        }
+    }
+
+    pub fn i_gt(&mut self, lhs: IntValue, rhs: IntValue, is_signed: bool) -> IntValue {
+        if is_signed {
+            self.build_icmp(LLVMIntPredicate::LLVMIntSGT, lhs, rhs)
+        } else {
+            self.build_icmp(LLVMIntPredicate::LLVMIntUGT, lhs, rhs)
+        }
+    }
+
+    pub fn i_shl(&mut self, lhs: IntValue, rhs: IntValue) -> IntValue {
+        let value = Values::new(unsafe {
+            LLVMBuildShl(
+                self.builder(),
+                lhs.as_value_ref(),
+                rhs.as_value_ref(),
+                self.default_zero_name(),
+            )
+        });
+
+        IntValue::new(value)
+    }
+
+    pub fn i_shr(&mut self, lhs: IntValue, rhs: IntValue, is_signed: bool) -> IntValue {
+        let value = Values::new(unsafe {
+            if is_signed {
+                LLVMBuildAShr(
+                    self.builder(),
+                    lhs.as_value_ref(),
+                    rhs.as_value_ref(),
+                    self.default_zero_name(),
+                )
+            } else {
+                LLVMBuildLShr(
+                    self.builder(),
+                    lhs.as_value_ref(),
+                    rhs.as_value_ref(),
+                    self.default_zero_name(),
+                )
+            }
+        });
+
+        IntValue::new(value)
+    }
+}

--- a/compiler/tahuc_codegen_llvm/src/llvm/binary/mod.rs
+++ b/compiler/tahuc_codegen_llvm/src/llvm/binary/mod.rs
@@ -1,0 +1,47 @@
+use tahuc_llvm::core::{LLVMBuildAnd, LLVMBuildOr, LLVMBuildXor};
+
+use crate::llvm::{Builder, IntValue, Values};
+
+mod float;
+mod int;
+
+impl Builder {
+    pub fn and(&mut self, lhs: IntValue, rhs: IntValue) -> IntValue {
+        let value = Values::new(unsafe {
+            LLVMBuildAnd(
+                self.builder(),
+                lhs.as_value_ref(),
+                rhs.as_value_ref(),
+                self.default_zero_name(),
+            )
+        });
+
+        IntValue::new(value)
+    }
+
+    pub fn or(&mut self, lhs: IntValue, rhs: IntValue) -> IntValue {
+        let value = Values::new(unsafe {
+            LLVMBuildOr(
+                self.builder(),
+                lhs.as_value_ref(),
+                rhs.as_value_ref(),
+                self.default_zero_name(),
+            )
+        });
+
+        IntValue::new(value)
+    }
+
+    pub fn xor(&mut self, lhs: IntValue, rhs: IntValue) -> IntValue {
+        let value = Values::new(unsafe {
+            LLVMBuildXor(
+                self.builder(),
+                lhs.as_value_ref(),
+                rhs.as_value_ref(),
+                self.default_zero_name(),
+            )
+        });
+
+        IntValue::new(value)
+    }
+}

--- a/compiler/tahuc_codegen_llvm/src/llvm/builder.rs
+++ b/compiler/tahuc_codegen_llvm/src/llvm/builder.rs
@@ -1,0 +1,196 @@
+use std::ffi::CString;
+
+use tahuc_llvm::{
+    core::*,
+    opaque::{LLVMBuilderRef, LLVMValueRef},
+};
+
+use crate::llvm::{
+    AsValueRef, BasicBlock, BasicValue, FloatValue, FunctionValue, IntValue, LLVMCastKind, PhiValue, PointerValue, Type, Values
+};
+
+pub struct Builder {
+    pub(crate) inner: LLVMBuilderRef,
+}
+
+impl Drop for Builder {
+    fn drop(&mut self) {
+        unsafe {
+            LLVMDisposeBuilder(self.builder());
+        }
+    }
+}
+
+impl Builder {
+    pub fn new(llvm_builder: LLVMBuilderRef) -> Self {
+        Self {
+            inner: llvm_builder,
+        }
+    }
+
+    pub fn ret_void(&mut self) -> Values {
+        Values::new(unsafe { LLVMBuildRetVoid(self.builder()) })
+    }
+
+    pub fn ret(&mut self, value: BasicValue) -> Values {
+        Values::new(unsafe { LLVMBuildRet(self.builder(), value.as_value_ref()) })
+    }
+
+    pub fn jump(&mut self, dest: BasicBlock) -> Values {
+        Values::new(unsafe { LLVMBuildBr(self.builder(), dest.as_block_ref()) })
+    }
+
+    pub fn branch(
+        &mut self,
+        condition: BasicValue,
+        then_branch: BasicBlock,
+        else_branch: BasicBlock,
+    ) -> Values {
+        Values::new(unsafe {
+            LLVMBuildCondBr(
+                self.builder(),
+                condition.as_value_ref(),
+                then_branch.as_block_ref(),
+                else_branch.as_block_ref(),
+            )
+        })
+    }
+
+    pub fn unreachable(&mut self) -> Values {
+        Values::new(unsafe { LLVMBuildUnreachable(self.builder()) })
+    }
+
+    pub fn position_at_end(&mut self, block: BasicBlock) {
+        unsafe { LLVMPositionBuilderAtEnd(self.builder(), block.as_block_ref()) }
+    }
+
+    pub fn alloca(&mut self, ty: Type) -> PointerValue {
+        let name = self.default_zero_name();
+
+        let value = Values::new(unsafe { LLVMBuildAlloca(self.builder(), ty.as_type_ref(), name) });
+
+        PointerValue::new(value)
+    }
+
+    pub fn load(&mut self, ty: Type, ptr: PointerValue) -> BasicValue {
+        let name = self.default_zero_name();
+        let value = Values::new(unsafe {
+            LLVMBuildLoad2(self.builder(), ty.as_type_ref(), ptr.as_value_ref(), name)
+        });
+
+        BasicValue::new(value)
+    }
+
+    pub fn store(&mut self, ptr: PointerValue, value: BasicValue) {
+        unsafe {
+            LLVMBuildStore(self.builder(), value.as_value_ref(), ptr.as_value_ref());
+        }
+    }
+
+    pub fn select(&mut self, cond: BasicValue, then: BasicValue, else_: BasicValue) -> BasicValue {
+        let name = self.default_zero_name();
+        let value = Values::new(unsafe {
+            LLVMBuildSelect(
+                self.builder(),
+                cond.as_value_ref(),
+                then.as_value_ref(),
+                else_.as_value_ref(),
+                name,
+            )
+        });
+
+        BasicValue::new(value)
+    }
+
+    pub fn gep(&mut self, ty: Type, ptr: PointerValue, indices: &[IntValue]) -> PointerValue {
+        let name = self.default_zero_name();
+        let mut indices: Vec<LLVMValueRef> = indices.iter().map(|val| val.as_value_ref()).collect();
+        let value = Values::new(unsafe {
+            LLVMBuildInBoundsGEP2(
+                self.builder(),
+                ty.as_type_ref(),
+                ptr.as_value_ref(),
+                indices.as_mut_ptr(),
+                indices.len() as u32,
+                name,
+            )
+        });
+
+        PointerValue::new(value)
+    }
+
+    pub fn call(&mut self, function: FunctionValue, args: &[BasicValue]) -> Values {
+        let ty = function.get_ty();
+        let func = function.as_value_ref();
+        let mut args: Vec<LLVMValueRef> = args.iter().map(|val| val.as_value_ref()).collect();
+        let name = self.default_zero_name();
+
+        let value = Values::new(unsafe {
+            LLVMBuildCall2(
+                self.builder(),
+                ty.as_type_ref(),
+                func,
+                args.as_mut_ptr(),
+                args.len() as u32,
+                name,
+            )
+        });
+
+        value
+    }
+
+    pub fn cast(&mut self, op: LLVMCastKind, value: BasicValue, ty: Type) -> BasicValue {
+        let name = self.default_zero_name();
+        let value = Values::new(unsafe {
+            LLVMBuildCast(
+                self.builder(),
+                op.as_llvm_opcode(),
+                value.as_value_ref(),
+                ty.as_type_ref(),
+                name,
+            )
+        });
+
+        BasicValue::new(value)
+    }
+
+    pub fn phi(&mut self, ty: Type) -> PhiValue {
+        let name = self.default_zero_name();
+        let value = Values::new(unsafe { LLVMBuildPhi(self.builder(), ty.as_type_ref(), name) });
+
+        PhiValue::new(value)
+    }
+
+    // unary
+    pub fn i_neg(&mut self, value: IntValue) -> IntValue {
+        let name = self.default_zero_name();
+        let value =
+            Values::new(unsafe { LLVMBuildNeg(self.builder(), value.as_value_ref(), name) });
+
+        IntValue::new(value)
+    }
+
+    pub fn f_neg(&mut self, value: FloatValue) -> FloatValue {
+        let name = self.default_zero_name();
+        let value = Values::new(unsafe { LLVMBuildFNeg(self.builder(), value.as_value_ref(), name) });
+
+        FloatValue::new(value)
+    }
+
+    pub fn i_not(&mut self, value: IntValue) -> IntValue {
+        let name = self.default_zero_name();
+        let value =
+            Values::new(unsafe { LLVMBuildNot(self.builder(), value.as_value_ref(), name) });
+
+        IntValue::new(value)
+    }
+
+    pub(crate) fn builder(&mut self) -> LLVMBuilderRef {
+        self.inner
+    }
+
+    pub(crate) fn default_zero_name(&self) -> *const i8 {
+        let res = CString::new("").unwrap();
+        res.as_ptr()
+    }
+}

--- a/compiler/tahuc_codegen_llvm/src/llvm/call.rs
+++ b/compiler/tahuc_codegen_llvm/src/llvm/call.rs
@@ -1,0 +1,25 @@
+pub enum CallConvention {
+    C,
+    FastCall,
+    ColdCall,
+
+    X86StdCall,
+    X86ThisCall,
+
+    SysVCall,
+    Win64Call
+}
+
+impl CallConvention {
+    pub fn as_llvm_call_conv(self) -> u32 {
+        match self {
+            CallConvention::C => 0,
+            CallConvention::FastCall => 8,
+            CallConvention::ColdCall => 9,
+            CallConvention::X86StdCall => 64,
+            CallConvention::X86ThisCall => 70,
+            CallConvention::SysVCall => 78,
+            CallConvention::Win64Call => 79,
+        }
+    }
+}

--- a/compiler/tahuc_codegen_llvm/src/llvm/cast.rs
+++ b/compiler/tahuc_codegen_llvm/src/llvm/cast.rs
@@ -1,0 +1,35 @@
+use tahuc_llvm::LLVMOpcode;
+
+pub enum LLVMCastKind {
+    Trunc,
+    ZExt,
+    SExt,
+    FPToUI,
+    FPToSI,
+    UIToFP,
+    SIToFP,
+    FPTrunc,
+    FPExt,
+    PtrToInt,
+    IntToPtr,
+    BitCast,
+}
+
+impl LLVMCastKind {
+    pub fn as_llvm_opcode(&self) -> LLVMOpcode {
+        match self {
+            LLVMCastKind::Trunc => LLVMOpcode::LLVMTrunc,
+            LLVMCastKind::ZExt => LLVMOpcode::LLVMZExt,
+            LLVMCastKind::SExt => LLVMOpcode::LLVMSExt,
+            LLVMCastKind::FPToUI => LLVMOpcode::LLVMFPToUI,
+            LLVMCastKind::FPToSI => LLVMOpcode::LLVMFPToSI,
+            LLVMCastKind::UIToFP => LLVMOpcode::LLVMUIToFP,
+            LLVMCastKind::SIToFP => LLVMOpcode::LLVMSIToFP,
+            LLVMCastKind::FPTrunc => LLVMOpcode::LLVMFPTrunc,
+            LLVMCastKind::FPExt => LLVMOpcode::LLVMFPExt,
+            LLVMCastKind::PtrToInt => LLVMOpcode::LLVMPtrToInt,
+            LLVMCastKind::IntToPtr => LLVMOpcode::LLVMIntToPtr,
+            LLVMCastKind::BitCast => LLVMOpcode::LLVMBitCast,
+        }
+    }
+}

--- a/compiler/tahuc_codegen_llvm/src/llvm/context.rs
+++ b/compiler/tahuc_codegen_llvm/src/llvm/context.rs
@@ -1,0 +1,142 @@
+use std::ffi::CString;
+
+use tahuc_llvm::{
+    core::{
+        LLVMArrayType, LLVMConstStringInContext, LLVMStructCreateNamed,
+        context::*,
+    },
+    opaque::LLVMContextRef,
+};
+
+use crate::llvm::{
+    ArrayType, ArrayValue, BasicBlock, BoolType, Builder, FloatType, FunctionValue, IntType,
+    Module, PointerType, StructType, Type, Values, VoidType,
+};
+
+#[derive(Debug, Clone, Copy)]
+pub struct Context {
+    ctx: LLVMContextRef,
+}
+
+impl Context {
+    pub fn new(ctx: LLVMContextRef) -> Self {
+        Self { ctx }
+    }
+
+    pub fn create() -> Self {
+        let ctx = unsafe { LLVMContextCreate() };
+
+        Context::new(ctx)
+    }
+
+    pub fn create_builder(&self) -> Builder {
+        let builder = unsafe { LLVMCreateBuilderInContext(self.ctx) };
+        Builder::new(builder)
+    }
+
+    pub fn create_module(&self, name: &str) -> Module {
+        let name = CString::new(name).unwrap();
+        let name = name.as_ptr();
+
+        let module = unsafe { LLVMModuleCreateWithNameInContext(name, self.ctx) };
+
+        Module::new(module)
+    }
+
+    pub fn append_basic_block(&self, function: FunctionValue, name: &str) -> BasicBlock {
+        let name = CString::new(name).unwrap();
+        let name = name.as_ptr();
+
+        BasicBlock::new(unsafe {
+            LLVMAppendBasicBlockInContext(self.ctx, function.as_value_ref(), name)
+        })
+    }
+
+    pub fn bool_ty(&self) -> BoolType {
+        let ty = Type::new(unsafe { LLVMInt1TypeInContext(self.ctx) });
+
+        BoolType::new(ty)
+    }
+
+    pub fn i8_ty(&self) -> IntType {
+        let ty = Type::new(unsafe { LLVMInt8TypeInContext(self.ctx) });
+
+        IntType::new(ty)
+    }
+
+    pub fn i16_ty(&self) -> IntType {
+        let ty = Type::new(unsafe { LLVMInt16TypeInContext(self.ctx) });
+
+        IntType::new(ty)
+    }
+
+    pub fn i32_ty(&self) -> IntType {
+        let ty = Type::new(unsafe { LLVMInt32TypeInContext(self.ctx) });
+
+        IntType::new(ty)
+    }
+
+    pub fn i64_ty(&self) -> IntType {
+        let ty = Type::new(unsafe { LLVMInt64TypeInContext(self.ctx) });
+
+        IntType::new(ty)
+    }
+
+    pub fn f32_ty(&self) -> FloatType {
+        let ty = Type::new(unsafe { LLVMFloatTypeInContext(self.ctx) });
+
+        FloatType::new(ty)
+    }
+
+    pub fn f64_ty(&self) -> FloatType {
+        let ty = Type::new(unsafe { LLVMDoubleTypeInContext(self.ctx) });
+
+        FloatType::new(ty)
+    }
+
+    pub fn custom_width_int_ty(&self, width: u32) -> IntType {
+        let ty = Type::new(unsafe { LLVMIntTypeInContext(self.ctx, width) });
+
+        IntType::new(ty)
+    }
+
+    pub fn void_ty(&self) -> VoidType {
+        let ty = Type::new(unsafe { LLVMVoidTypeInContext(self.ctx) });
+
+        VoidType::new(ty)
+    }
+
+    pub fn array_ty(&self, element_ty: Type, element_count: u32) -> ArrayType {
+        let ty = Type::new(unsafe { LLVMArrayType(element_ty.as_type_ref(), element_count) });
+
+        ArrayType::new(ty, element_count)
+    }
+
+    pub fn ptr_ty(&self) -> PointerType {
+        let ty = Type::new(unsafe { LLVMPointerTypeInContext(self.ctx, 0) });
+
+        PointerType::new(ty)
+    }
+
+    pub fn struct_ty(&self, name: &str) -> StructType {
+        let name = CString::new(name).unwrap();
+        let name = name.as_ptr();
+
+        let ty = Type::new(unsafe { LLVMStructCreateNamed(self.ctx, name) });
+
+        StructType::new(ty)
+    }
+
+    pub fn const_string(self, string: &[u8], null_terminated: bool) -> ArrayValue {
+        let value = Values::new(unsafe {
+            LLVMConstStringInContext(
+                self.ctx,
+                string.as_ptr() as *const i8,
+                string.len() as u32,
+                !null_terminated as i32,
+            )
+        });
+
+        ArrayValue::new(value)
+    }
+}

--- a/compiler/tahuc_codegen_llvm/src/llvm/mod.rs
+++ b/compiler/tahuc_codegen_llvm/src/llvm/mod.rs
@@ -1,0 +1,86 @@
+mod basic_block;
+mod binary;
+mod builder;
+mod context;
+mod module;
+mod types;
+mod values;
+mod target;
+mod cast;
+mod call;
+
+pub use basic_block::*;
+pub use builder::*;
+pub use context::*;
+pub use module::*;
+pub use types::*;
+pub use values::*;
+pub use target::*;
+pub use cast::*;
+pub use call::*;
+
+pub enum Visibility {
+    /// default
+    Public,
+
+    /// private or hidden
+    Private,
+
+    /// protected
+    Protected,
+}
+
+impl Visibility {
+    pub fn as_llvm_visibility(self) -> tahuc_llvm::LLVMVisibility {
+        match self {
+            Visibility::Public => tahuc_llvm::LLVMVisibility::LLVMDefaultVisibility,
+            Visibility::Private => tahuc_llvm::LLVMVisibility::LLVMHiddenVisibility,
+            Visibility::Protected => tahuc_llvm::LLVMVisibility::LLVMProtectedVisibility,
+        }
+    }
+}
+
+pub enum Linkage {
+    /// external
+    External,
+
+    /// available externally
+    AvailableExternally,
+
+    /// link once
+    LinkOnce,
+
+    /// weak
+    Weak,
+
+    /// appending
+    Appending,
+
+    /// internal
+    Internal,
+
+    /// private
+    Private,
+
+    /// external weak
+    ExternalWeak,
+
+    /// common
+    Common,
+}
+
+impl Linkage {
+    pub fn as_llvm_linkage(self) -> tahuc_llvm::LLVMLinkage {
+        match self {
+            Linkage::External => tahuc_llvm::LLVMLinkage::LLVMExternalLinkage,
+            Linkage::AvailableExternally => tahuc_llvm::LLVMLinkage::LLVMAvailableExternallyLinkage,
+            Linkage::LinkOnce => tahuc_llvm::LLVMLinkage::LLVMLinkOnceAnyLinkage,
+            Linkage::Weak => tahuc_llvm::LLVMLinkage::LLVMWeakAnyLinkage,
+            Linkage::Appending => tahuc_llvm::LLVMLinkage::LLVMAppendingLinkage,
+            Linkage::Internal => tahuc_llvm::LLVMLinkage::LLVMInternalLinkage,
+            Linkage::Private => tahuc_llvm::LLVMLinkage::LLVMPrivateLinkage,
+            Linkage::ExternalWeak => tahuc_llvm::LLVMLinkage::LLVMExternalWeakLinkage,
+            Linkage::Common => tahuc_llvm::LLVMLinkage::LLVMCommonLinkage,
+        }
+    }
+}

--- a/compiler/tahuc_codegen_llvm/src/llvm/module.rs
+++ b/compiler/tahuc_codegen_llvm/src/llvm/module.rs
@@ -1,0 +1,66 @@
+use std::mem::MaybeUninit;
+
+use tahuc_llvm::{
+    analysis::{LLVMVerifierFailureAction, LLVMVerifyModule},
+    core::{LLVMAddFunction, LLVMAddGlobalInAddressSpace, LLVMPrintModuleToString},
+    opaque::LLVMModuleRef,
+};
+
+use crate::llvm::{FunctionType, FunctionValue, GlobalValue, Type, Values};
+
+#[derive(Debug, Clone, Copy)]
+pub struct Module {
+    module: LLVMModuleRef,
+}
+
+impl Module {
+    pub fn new(module: LLVMModuleRef) -> Self {
+        Self { module }
+    }
+
+    pub fn add_function(&self, name: &str, ty: FunctionType) -> FunctionValue {
+        let name = std::ffi::CString::new(name).unwrap();
+        let name = name.as_ptr();
+
+        let value = Values::new(unsafe { LLVMAddFunction(self.module, name, ty.as_type_ref()) });
+
+        FunctionValue::new(value)
+    }
+
+    pub fn add_global(&self, ty: Type, name: &str) -> GlobalValue {
+        let name = std::ffi::CString::new(name).unwrap();
+        let name = name.as_ptr();
+        let value = Values::new(unsafe {
+            LLVMAddGlobalInAddressSpace(self.module, ty.as_type_ref(), name, 0)
+        });
+
+        GlobalValue::new(value)
+    }
+
+    pub fn verify(&self) -> Result<(), String> {
+        let mut err_str = MaybeUninit::uninit();
+        let action = LLVMVerifierFailureAction::LLVMPrintMessageAction;
+
+        let code = unsafe { LLVMVerifyModule(self.module, action, err_str.as_mut_ptr()) };
+
+        let err_str = unsafe { err_str.assume_init() };
+        if code == 1 && !err_str.is_null() {
+            let err_str = unsafe { std::ffi::CStr::from_ptr(err_str) };
+            return Err(err_str.to_string_lossy().into_owned());
+        }
+
+        Ok(())
+    }
+
+    pub fn print_to_string(&self) -> String {
+        let str = unsafe { LLVMPrintModuleToString(self.module) };
+        let str = unsafe { std::ffi::CStr::from_ptr(str) };
+        str.to_string_lossy().into_owned()
+    }
+}
+
+impl From<Module> for LLVMModuleRef {
+    fn from(value: Module) -> Self {
+        value.module
+    }
+}

--- a/compiler/tahuc_codegen_llvm/src/llvm/target.rs
+++ b/compiler/tahuc_codegen_llvm/src/llvm/target.rs
@@ -1,0 +1,328 @@
+use std::{mem::MaybeUninit};
+
+use tahuc_llvm::{
+    target::*,
+    target_machine::*,
+};
+
+use crate::llvm::Module;
+
+pub enum OptLevel {
+    None = 0,
+    Less = 1,
+    Default = 2,
+    Aggressive = 3,
+}
+
+impl From<OptLevel> for LLVMCodeGenOptLevel {
+    fn from(level: OptLevel) -> Self {
+        match level {
+            OptLevel::None => LLVMCodeGenOptLevel::LLVMCodeGenLevelNone,
+            OptLevel::Less => LLVMCodeGenOptLevel::LLVMCodeGenLevelLess,
+            OptLevel::Default => LLVMCodeGenOptLevel::LLVMCodeGenLevelDefault,
+            OptLevel::Aggressive => LLVMCodeGenOptLevel::LLVMCodeGenLevelAggressive,
+        }
+    }
+}
+
+pub enum CodeModel {
+    Default,
+    Small,
+    Kernel,
+    Medium,
+    Large,
+}
+
+impl From<CodeModel> for LLVMCodeModel {
+    fn from(value: CodeModel) -> Self {
+        match value {
+            CodeModel::Default => LLVMCodeModel::LLVMCodeModelDefault,
+            CodeModel::Small => LLVMCodeModel::LLVMCodeModelSmall,
+            CodeModel::Kernel => LLVMCodeModel::LLVMCodeModelKernel,
+            CodeModel::Medium => LLVMCodeModel::LLVMCodeModelMedium,
+            CodeModel::Large => LLVMCodeModel::LLVMCodeModelLarge,
+        }
+    }
+}
+
+pub enum RelocMode {
+    Default,
+    Static,
+    PIC,
+    DynamicNoPIC,
+}
+
+impl From<RelocMode> for LLVMRelocMode {
+    fn from(value: RelocMode) -> Self {
+        match value {
+            RelocMode::Default => LLVMRelocMode::LLVMRelocDefault,
+            RelocMode::Static => LLVMRelocMode::LLVMRelocStatic,
+            RelocMode::PIC => LLVMRelocMode::LLVMRelocPIC,
+            RelocMode::DynamicNoPIC => LLVMRelocMode::LLVMRelocDynamicNoPic,
+        }
+    }
+}
+
+pub enum FileType {
+    Assembly,
+    Object,
+}
+
+impl FileType {
+    fn as_llvm_file_type(&self) -> LLVMCodeGenFileType {
+        match *self {
+            FileType::Assembly => LLVMCodeGenFileType::LLVMAssemblyFile,
+            FileType::Object => LLVMCodeGenFileType::LLVMObjectFile,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct CString {
+    ptr: *const std::ffi::c_char,
+}
+
+impl CString {
+    pub fn new(str: &str) -> Self {
+        let ptr = std::ffi::CString::new(str).unwrap();
+        Self { ptr: ptr.into_raw() }
+    }
+
+    pub fn from_raw(ptr: *mut i8) -> String {
+        let str = unsafe { std::ffi::CString::from_raw(ptr) };
+        str.to_string_lossy().into_owned()
+    }
+
+    pub fn as_ptr(&self) -> *const std::ffi::c_char {
+        self.ptr
+    }
+
+    pub fn to_string(&self) -> String {
+        let str = unsafe { std::ffi::CStr::from_ptr(self.ptr) };
+        str.to_string_lossy().into_owned()
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct TargetTriple {
+    triple: CString,
+}
+
+impl TargetTriple {
+    pub fn new(triple: &str) -> Self {
+        Self {
+            triple: CString::new(triple),
+        }
+    }
+
+    pub fn create(triple: &str) -> Self {
+        Self {
+            triple: CString::new(triple),
+        }
+    }
+
+    pub fn default() -> Self {
+        let triple = unsafe { LLVMGetDefaultTargetTriple() };
+        Self {
+            triple: CString::new(
+                unsafe { std::ffi::CStr::from_ptr(triple) }
+                    .to_string_lossy()
+                    .as_ref(),
+            ),
+        }
+    }
+}
+
+pub struct Target {
+    target: LLVMTargetRef,
+}
+
+impl Target {
+    pub fn new(target: LLVMTargetRef) -> Self {
+        Self { target }
+    }
+
+    pub fn from_triple(triple: TargetTriple) -> Self {
+        let mut target = std::ptr::null_mut();
+        let mut err_string = MaybeUninit::uninit();
+
+        unsafe {
+            LLVMGetTargetFromTriple(triple.triple.as_ptr(), &mut target, err_string.as_mut_ptr())
+        };
+        Target::new(target)
+    }
+
+    pub fn init_x86() {
+        Init::x86();
+    }
+
+    pub fn init_arm() {
+        Init::arm();
+    }
+
+    pub fn init_arch64() {
+        Init::arch64();
+    }
+
+    pub fn init_amdgpu() {
+        Init::amdgpu();
+    }
+
+    pub fn init_loongarch() {
+        Init::loongarch();
+    }
+
+    pub fn init_mips() {
+        Init::mips();
+    }
+
+    pub fn init_wasm() {
+        Init::wasm();
+    }
+
+    pub fn create_target_machine(
+        &self,
+        triple: TargetTriple,
+        cpu: &str,
+        features: &str,
+        opt_level: OptLevel,
+        reloc_mode: RelocMode,
+        code_model: CodeModel,
+    ) -> TargetMachine {
+        let cpu = CString::new(cpu);
+        let features = CString::new(features);
+
+        let target = unsafe {
+            LLVMCreateTargetMachine(
+                self.target,
+                triple.triple.as_ptr(),
+                cpu.as_ptr(),
+                features.as_ptr(),
+                opt_level.into(),
+                reloc_mode.into(),
+                code_model.into(),
+            )
+        };
+
+        TargetMachine::new(target)
+    }
+}
+
+struct Init;
+
+impl Init {
+    pub fn x86() {
+        unsafe {
+            LLVMInitializeX86TargetInfo();
+            LLVMInitializeX86Target();
+            LLVMInitializeX86TargetMC();
+            LLVMInitializeX86AsmPrinter();
+            LLVMInitializeX86AsmParser();
+        }
+    }
+
+    pub fn arm() {
+        unsafe {
+            LLVMInitializeARMTargetInfo();
+            LLVMInitializeARMTarget();
+            LLVMInitializeARMTargetMC();
+            LLVMInitializeARMAsmPrinter();
+            LLVMInitializeARMAsmParser();
+        }
+    }
+
+    pub fn arch64() {
+        unsafe {
+            LLVMInitializeAArch64TargetInfo();
+            LLVMInitializeAArch64Target();
+            LLVMInitializeAArch64TargetMC();
+            LLVMInitializeAArch64AsmPrinter();
+            LLVMInitializeAArch64AsmParser();
+        }
+    }
+
+    pub fn amdgpu() {
+        unsafe {
+            LLVMInitializeAMDGPUTargetInfo();
+            LLVMInitializeAMDGPUTarget();
+            LLVMInitializeAMDGPUTargetMC();
+            LLVMInitializeAMDGPUAsmPrinter();
+            LLVMInitializeAMDGPUAsmParser();
+        }
+    }
+
+    pub fn loongarch() {
+        unsafe {
+            LLVMInitializeLoongArchTargetInfo();
+            LLVMInitializeLoongArchTarget();
+            LLVMInitializeLoongArchTargetMC();
+            LLVMInitializeLoongArchAsmPrinter();
+            LLVMInitializeLoongArchAsmParser();
+        }
+    }
+
+    pub fn mips() {
+        unsafe {
+            LLVMInitializeMipsTargetInfo();
+            LLVMInitializeMipsTarget();
+            LLVMInitializeMipsTargetMC();
+            LLVMInitializeMipsAsmPrinter();
+            LLVMInitializeMipsAsmParser();
+        }
+    }
+
+    pub fn wasm() {
+        unsafe {
+            LLVMInitializeWebAssemblyTargetInfo();
+            LLVMInitializeWebAssemblyTarget();
+            LLVMInitializeWebAssemblyTargetMC();
+            LLVMInitializeWebAssemblyAsmPrinter();
+            LLVMInitializeWebAssemblyAsmParser();
+        }
+    }
+}
+
+pub struct TargetMachine {
+    machine: LLVMTargetMachineRef,
+}
+
+impl TargetMachine {
+    pub fn new(machine: LLVMTargetMachineRef) -> Self {
+        Self { machine }
+    }
+
+    pub fn emit_to_file(
+        &self,
+        module: Module,
+        filename: &str,
+        file_type: FileType,
+    ) -> Result<(), String> {
+        let filename = CString::new(filename);
+        let mut error: *mut std::ffi::c_char = std::ptr::null_mut();
+
+        let result = unsafe {
+            LLVMTargetMachineEmitToFile(
+                self.machine,
+                module.into(),
+                filename.as_ptr() as *mut std::ffi::c_char,
+                file_type.as_llvm_file_type(),
+                &mut error,
+            )
+        };
+
+        if result == 0 {
+            Ok(())
+        } else {
+            let err_msg = unsafe { std::ffi::CStr::from_ptr(error) }
+                .to_string_lossy()
+                .into_owned();
+            Err(err_msg)
+        }
+    }
+}
+
+impl Drop for TargetMachine {
+    fn drop(&mut self) {
+        unsafe { LLVMDisposeTargetMachine(self.machine) };
+    }
+}

--- a/compiler/tahuc_codegen_llvm/src/llvm/types/array.rs
+++ b/compiler/tahuc_codegen_llvm/src/llvm/types/array.rs
@@ -1,0 +1,27 @@
+use tahuc_llvm::{opaque::LLVMTypeRef};
+
+use super::super::types::{fn_ty::FunctionType, Type};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ArrayType {
+    ty: Type,
+    size: u32,
+}
+
+impl ArrayType {
+    pub fn new(ty: Type, size: u32) -> Self {
+        Self { ty, size }
+    }
+
+    pub fn as_type_ref(self) -> LLVMTypeRef {
+        self.ty.as_type_ref()
+    }
+
+    pub fn as_ty(self) -> Type {
+        self.ty
+    }
+
+    pub fn fn_ty(self, params: &[Type], is_var_arg: bool) -> FunctionType {
+        self.ty.fn_ty(params, is_var_arg)
+    }
+}

--- a/compiler/tahuc_codegen_llvm/src/llvm/types/bool.rs
+++ b/compiler/tahuc_codegen_llvm/src/llvm/types/bool.rs
@@ -1,0 +1,36 @@
+use tahuc_llvm::{
+    core::{LLVMConstInt},
+    opaque::LLVMTypeRef,
+};
+
+use crate::llvm::{FunctionType, IntValue, Type, Values};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct BoolType {
+    ty: Type,
+}
+
+impl BoolType {
+    pub fn new(ty: Type) -> Self {
+        Self { ty }
+    }
+
+    pub fn as_type_ref(self) -> LLVMTypeRef {
+        self.ty.as_type_ref()
+    }
+
+    pub fn fn_ty(self, params: &[Type], is_var_arg: bool) -> FunctionType {
+        self.ty.fn_ty(params, is_var_arg)
+    }
+
+    pub fn const_bool(self, value: u64, sign_extend: bool) -> IntValue {
+        let value = Values::new(unsafe {
+            LLVMConstInt(self.as_type_ref(), value, sign_extend as i32)
+        });
+        IntValue::new(value)
+    }
+
+    pub fn as_ty(self) -> Type {
+        self.ty
+    }
+}

--- a/compiler/tahuc_codegen_llvm/src/llvm/types/float.rs
+++ b/compiler/tahuc_codegen_llvm/src/llvm/types/float.rs
@@ -1,0 +1,31 @@
+use tahuc_llvm::{core::LLVMConstReal, opaque::LLVMTypeRef};
+
+use crate::llvm::{FloatValue, FunctionType, Type, Values};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct FloatType {
+    ty: Type,
+}
+
+impl FloatType {
+    pub fn new(ty: Type) -> Self {
+        Self { ty }
+    }
+
+    pub fn as_type_ref(self) -> LLVMTypeRef {
+        self.ty.as_type_ref()
+    }
+
+    pub fn fn_ty(self, params: &[Type], is_var_arg: bool) -> FunctionType {
+        self.ty.fn_ty(params, is_var_arg)
+    }
+
+    pub fn const_float(self, value: f64) -> FloatValue {
+        let value = Values::new(unsafe { LLVMConstReal(self.as_type_ref(), value) });
+        FloatValue::new(value)
+    }
+
+    pub fn as_ty(self) -> Type {
+        self.ty
+    }
+}

--- a/compiler/tahuc_codegen_llvm/src/llvm/types/fn_ty.rs
+++ b/compiler/tahuc_codegen_llvm/src/llvm/types/fn_ty.rs
@@ -1,0 +1,18 @@
+use tahuc_llvm::opaque::LLVMTypeRef;
+
+use crate::llvm::Type;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct FunctionType {
+    ty: Type,
+}
+
+impl FunctionType {
+    pub fn new(ty: Type) -> Self {
+        Self { ty }
+    }
+
+    pub fn as_type_ref(self) -> LLVMTypeRef {
+        self.ty.as_type_ref()
+    }
+}

--- a/compiler/tahuc_codegen_llvm/src/llvm/types/int.rs
+++ b/compiler/tahuc_codegen_llvm/src/llvm/types/int.rs
@@ -1,0 +1,36 @@
+use tahuc_llvm::{core::{LLVMConstInt, LLVMGetIntTypeWidth}, opaque::LLVMTypeRef};
+
+use crate::llvm::{FunctionType, IntValue, Type, Values};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct IntType {
+    ty: Type,
+}
+
+impl IntType {
+    pub fn new(ty: Type) -> Self {
+        Self { ty }
+    }
+
+    pub fn as_type_ref(self) -> LLVMTypeRef {
+        self.ty.as_type_ref()
+    }
+
+    pub fn fn_ty(self, params: &[Type], is_var_arg: bool) -> FunctionType {
+        self.ty.fn_ty(params, is_var_arg)
+    }
+
+    pub fn const_int(self, value: u64, sign_extend: bool) -> IntValue {
+        let value =
+            Values::new(unsafe { LLVMConstInt(self.as_type_ref(), value, sign_extend as i32) });
+        IntValue::new(value)
+    }
+
+    pub fn as_ty(self) -> Type {
+        self.ty
+    }
+
+    pub fn get_bit_width(self) -> u32 {
+        unsafe { LLVMGetIntTypeWidth(self.as_type_ref()) }
+    }
+}

--- a/compiler/tahuc_codegen_llvm/src/llvm/types/mod.rs
+++ b/compiler/tahuc_codegen_llvm/src/llvm/types/mod.rs
@@ -1,0 +1,52 @@
+mod array;
+mod bool;
+mod float;
+mod fn_ty;
+mod int;
+mod pointee;
+mod struct_ty;
+mod void;
+
+pub use array::*;
+pub use bool::*;
+pub use float::*;
+pub use fn_ty::*;
+pub use int::*;
+pub use pointee::*;
+pub use void::*;
+pub use struct_ty::*;
+
+use tahuc_llvm::{core::LLVMFunctionType, opaque::LLVMTypeRef};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Type {
+    ty: LLVMTypeRef,
+}
+
+impl Type {
+    pub fn new(ty: LLVMTypeRef) -> Self {
+        Self { ty }
+    }
+
+    pub fn as_type_ref(self) -> LLVMTypeRef {
+        self.ty
+    }
+
+    pub fn fn_ty(self, params: &[Type], is_var_arg: bool) -> FunctionType {
+        let mut param_ref: Vec<LLVMTypeRef> = params.iter().map(|t| t.as_type_ref()).collect();
+        let ty = Type::new(unsafe {
+            LLVMFunctionType(
+                self.as_type_ref(),
+                param_ref.as_mut_ptr(),
+                params.len() as std::ffi::c_uint,
+                is_var_arg as std::ffi::c_int,
+            )
+        });
+
+        FunctionType::new(ty)
+    }
+
+    pub fn into_int_ty(self) -> IntType {
+        IntType::new(self)
+    }
+}

--- a/compiler/tahuc_codegen_llvm/src/llvm/types/pointee.rs
+++ b/compiler/tahuc_codegen_llvm/src/llvm/types/pointee.rs
@@ -1,0 +1,31 @@
+use tahuc_llvm::{core::LLVMConstPointerNull, opaque::LLVMTypeRef};
+
+use crate::llvm::{FunctionType, PointerValue, Type, Values};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct PointerType {
+    ty: Type,
+}
+
+impl PointerType {
+    pub fn new(ty: Type) -> Self {
+        Self { ty }
+    }
+
+    pub fn as_type_ref(self) -> LLVMTypeRef {
+        self.ty.as_type_ref()
+    }
+
+    pub fn fn_ty(self, params: &[Type], is_var_arg: bool) -> FunctionType {
+        self.ty.fn_ty(params, is_var_arg)
+    }
+
+    pub fn const_null(self) -> PointerValue {
+        let value = Values::new(unsafe { LLVMConstPointerNull(self.as_type_ref()) });
+        PointerValue::new(value)
+    }
+
+    pub fn as_ty(self) -> Type {
+        self.ty
+    }
+}

--- a/compiler/tahuc_codegen_llvm/src/llvm/types/struct_ty.rs
+++ b/compiler/tahuc_codegen_llvm/src/llvm/types/struct_ty.rs
@@ -1,0 +1,39 @@
+use tahuc_llvm::{core::LLVMStructSetBody, opaque::LLVMTypeRef};
+
+use crate::llvm::{FunctionType, Type};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct StructType {
+    ty: Type,
+}
+
+impl StructType {
+    pub fn new(ty: Type) -> Self {
+        Self { ty }
+    }
+
+    pub fn set_body(self, element_types: &[Type], packed: bool) {
+        let mut element_ty: Vec<LLVMTypeRef> =
+            element_types.iter().map(|val| val.as_type_ref()).collect();
+        unsafe {
+            LLVMStructSetBody(
+                self.ty.as_type_ref(),
+                element_ty.as_mut_ptr(),
+                element_ty.len() as std::ffi::c_uint,
+                packed as std::ffi::c_int,
+            );
+        }
+    }
+
+    pub fn as_ty(self) -> Type {
+        self.ty
+    }
+
+    pub fn as_type_ref(self) -> LLVMTypeRef {
+        self.ty.as_type_ref()
+    }
+
+    pub fn fn_ty(self, params: &[Type], is_var_arg: bool) -> FunctionType {
+        self.ty.fn_ty(params, is_var_arg)
+    }
+}

--- a/compiler/tahuc_codegen_llvm/src/llvm/types/void.rs
+++ b/compiler/tahuc_codegen_llvm/src/llvm/types/void.rs
@@ -1,0 +1,26 @@
+use tahuc_llvm::{opaque::LLVMTypeRef};
+
+use crate::llvm::{FunctionType, Type};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct VoidType {
+    ty: Type,
+}
+
+impl VoidType {
+    pub fn new(ty: Type) -> Self {
+        Self { ty }
+    }
+
+    pub fn as_type_ref(self) -> LLVMTypeRef {
+        self.ty.as_type_ref()
+    }
+
+    pub fn as_ty(self) -> Type {
+        self.ty
+    }
+
+    pub fn fn_ty(self, params: &[Type], is_var_arg: bool) -> FunctionType {
+        self.ty.fn_ty(params, is_var_arg)
+    }
+}

--- a/compiler/tahuc_codegen_llvm/src/llvm/values/array.rs
+++ b/compiler/tahuc_codegen_llvm/src/llvm/values/array.rs
@@ -1,0 +1,22 @@
+use tahuc_llvm::opaque::LLVMValueRef;
+
+use crate::llvm::{Type, Values};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ArrayValue {
+    value: Values,
+}
+
+impl ArrayValue {
+    pub fn new(value: Values) -> Self {
+        Self { value }
+    }
+
+    pub fn as_value_ref(self) -> LLVMValueRef {
+        self.value.into()
+    }
+
+    pub fn get_type(self) -> Type {
+        Type::new(self.value.get_type())
+    }
+}

--- a/compiler/tahuc_codegen_llvm/src/llvm/values/enums.rs
+++ b/compiler/tahuc_codegen_llvm/src/llvm/values/enums.rs
@@ -1,0 +1,113 @@
+use tahuc_llvm::{opaque::LLVMValueRef, LLVMTypeKind};
+
+use super::super::values::{ArrayValue, FloatValue, FunctionValue, IntValue, PointerValue, StructValue};
+use super::{AsValueRef, Values};
+
+macro_rules! enum_value_set {
+    ($enum_name:ident: $($args:ident),*) => (
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+        pub enum $enum_name {
+            $(
+                $args($args),
+            )*
+        }
+
+        impl AsValueRef for $enum_name {
+            fn as_value_ref(&self) -> LLVMValueRef {
+                match *self {
+                    $(
+                        $enum_name::$args(ref t) => t.as_value_ref(),
+                    )*
+                }
+            }
+        }
+
+        $(
+            impl From<$args> for $enum_name {
+                fn from(value: $args) -> $enum_name {
+                    $enum_name::$args(value)
+                }
+            }
+
+            impl PartialEq<$args> for $enum_name {
+                fn eq(&self, other: &$args) -> bool {
+                    self.as_value_ref() == other.as_value_ref()
+                }
+            }
+
+            impl PartialEq<$enum_name> for $args {
+                fn eq(&self, other: &$enum_name) -> bool {
+                    self.as_value_ref() == other.as_value_ref()
+                }
+            }
+
+            impl TryFrom<$enum_name> for $args {
+                type Error = ();
+
+                fn try_from(value: $enum_name) -> Result<Self, Self::Error> {
+                    match value {
+                        $enum_name::$args(ty) => Ok(ty),
+                        _ => Err(()),
+                    }
+                }
+            }
+        )*
+    );
+}
+
+enum_value_set! { BasicValue: IntValue, FloatValue, FunctionValue, PointerValue, ArrayValue, StructValue }
+
+impl BasicValue {
+    pub fn new(value: Values) -> BasicValue {
+        match value.kind() {
+            LLVMTypeKind::LLVMFloatTypeKind
+            | LLVMTypeKind::LLVMFP128TypeKind
+            | LLVMTypeKind::LLVMDoubleTypeKind
+            | LLVMTypeKind::LLVMHalfTypeKind
+            | LLVMTypeKind::LLVMX86_FP80TypeKind
+            | LLVMTypeKind::LLVMPPC_FP128TypeKind => BasicValue::FloatValue(FloatValue::new(value)),
+            LLVMTypeKind::LLVMIntegerTypeKind => BasicValue::IntValue(IntValue::new(value)),
+            LLVMTypeKind::LLVMStructTypeKind => BasicValue::StructValue(StructValue::new(value)),
+            LLVMTypeKind::LLVMPointerTypeKind => BasicValue::PointerValue(PointerValue::new(value)),
+            LLVMTypeKind::LLVMArrayTypeKind => BasicValue::ArrayValue(ArrayValue::new(value)),
+
+            _ => unreachable!("The given type is not a basic type., {:?}", value.kind()),
+        }
+    }
+
+    pub fn is_int_value(self) -> bool {
+        matches!(self, BasicValue::IntValue(_))
+    }
+
+    pub fn is_float_value(self) -> bool {
+        matches!(self, BasicValue::FloatValue(_))
+    }
+
+    pub fn is_pointer_value(self) -> bool {
+        matches!(self, BasicValue::PointerValue(_))
+    }
+
+    pub fn into_int_value(self) -> IntValue {
+        if let BasicValue::IntValue(v) = self {
+            v
+        } else {
+            panic!("Found {:?} but expected the IntValue variant", self)
+        }
+    }
+
+    pub fn into_float_value(self) -> FloatValue {
+        if let BasicValue::FloatValue(v) = self {
+            v
+        } else {
+            panic!("Found {:?} but expected the FloatValue variant", self)
+        }
+    }
+
+    pub fn into_ptr_value(self) -> PointerValue {
+        if let BasicValue::PointerValue(v) = self {
+            v
+        } else {
+            panic!("Found {:?} but expected the PointerValue variant", self)
+        }
+    }
+}

--- a/compiler/tahuc_codegen_llvm/src/llvm/values/float.rs
+++ b/compiler/tahuc_codegen_llvm/src/llvm/values/float.rs
@@ -1,0 +1,22 @@
+use tahuc_llvm::opaque::LLVMValueRef;
+
+use crate::llvm::Values;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct FloatValue {
+    value: Values,
+}
+
+impl FloatValue {
+    pub fn new(value: Values) -> Self {
+        Self { value }
+    }
+
+    pub fn as_value(self) -> Values {
+        self.value
+    }
+
+    pub fn as_value_ref(self) -> LLVMValueRef {
+        self.value.into()
+    }
+}

--- a/compiler/tahuc_codegen_llvm/src/llvm/values/fn_value.rs
+++ b/compiler/tahuc_codegen_llvm/src/llvm/values/fn_value.rs
@@ -1,0 +1,45 @@
+use tahuc_llvm::{
+    core::{LLVMGlobalGetValueType, LLVMSetFunctionCallConv, LLVMSetLinkage, LLVMSetVisibility},
+    opaque::LLVMValueRef,
+};
+
+use crate::llvm::{BasicValue, CallConvention, FunctionType, Linkage, Type, Values, Visibility};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct FunctionValue {
+    value: Values,
+}
+
+impl FunctionValue {
+    pub fn new(value: Values) -> Self {
+        Self { value }
+    }
+
+    pub fn as_value_ref(self) -> LLVMValueRef {
+        self.value.into()
+    }
+
+    pub fn set_linkage(self, linkage: Linkage) {
+        unsafe { LLVMSetLinkage(self.as_value_ref(), linkage.as_llvm_linkage()) };
+    }
+
+    pub fn set_visibility(self, visibility: Visibility) {
+        unsafe { LLVMSetVisibility(self.as_value_ref(), visibility.as_llvm_visibility()) };
+    }
+
+    pub fn set_call_convention(self, cc: CallConvention) {
+        unsafe {
+            LLVMSetFunctionCallConv(self.as_value_ref(), cc.as_llvm_call_conv());
+        }
+    }
+
+    pub fn get_ty(self) -> FunctionType {
+        let ty = Type::new(unsafe { LLVMGlobalGetValueType(self.as_value_ref()) });
+        FunctionType::new(ty)
+    }
+
+    pub fn get_param_at(self, index: usize) -> BasicValue {
+        let param = unsafe { tahuc_llvm::core::LLVMGetParam(self.as_value_ref(), index as u32) };
+        BasicValue::new(Values::new(param))
+    }
+}

--- a/compiler/tahuc_codegen_llvm/src/llvm/values/global.rs
+++ b/compiler/tahuc_codegen_llvm/src/llvm/values/global.rs
@@ -1,0 +1,42 @@
+use tahuc_llvm::{core::{LLVMSetInitializer, LLVMSetLinkage, LLVMSetVisibility}, opaque::LLVMValueRef,};
+
+use crate::llvm::{AsValueRef, BasicValue, Linkage, PointerValue, Type, Values, Visibility};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct GlobalValue {
+    value: Values,
+}
+
+impl GlobalValue {
+    pub fn new(value: Values) -> Self {
+        Self { value }
+    }
+
+    pub fn as_value_ref(self) -> LLVMValueRef {
+        self.value.into()
+    }
+
+    pub fn as_value(self) -> Values {
+        self.value
+    }
+
+    pub fn get_type(self) -> Type {
+        Type::new(self.value.get_type())
+    }
+
+    pub fn set_linkage(self, linkage: Linkage) {
+        unsafe { LLVMSetLinkage(self.as_value_ref(), linkage.as_llvm_linkage()) };
+    }
+
+    pub fn set_visibility(self, visibility: Visibility) {
+        unsafe { LLVMSetVisibility(self.as_value_ref(), visibility.as_llvm_visibility()) };
+    }
+
+    pub fn as_ptr(self) -> PointerValue {
+        PointerValue::new(self.value)
+    }
+
+    pub fn set_initializer(self, value: BasicValue) {
+        unsafe { LLVMSetInitializer(self.as_value_ref(), value.as_value_ref()) }
+    }
+}

--- a/compiler/tahuc_codegen_llvm/src/llvm/values/int.rs
+++ b/compiler/tahuc_codegen_llvm/src/llvm/values/int.rs
@@ -1,0 +1,28 @@
+use tahuc_llvm::{opaque::LLVMValueRef};
+
+use crate::llvm::{IntType, Type, Values};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct IntValue {
+    value: Values
+}
+
+impl IntValue {
+    pub fn new(value: Values) -> Self {
+        Self {
+            value,
+        }
+    }
+
+    pub fn as_value_ref(self) -> LLVMValueRef {
+        self.value.into()
+    }
+
+    pub fn as_value(self) -> Values {
+        self.value
+    }
+
+    pub fn get_ty(self) -> IntType {
+        IntType::new(Type::new(self.value.get_type()))
+    }
+}

--- a/compiler/tahuc_codegen_llvm/src/llvm/values/mod.rs
+++ b/compiler/tahuc_codegen_llvm/src/llvm/values/mod.rs
@@ -1,0 +1,54 @@
+use tahuc_llvm::{
+    core::{LLVMGetTypeKind, LLVMTypeOf}, opaque::{LLVMTypeRef, LLVMValueRef}, LLVMTypeKind
+};
+
+mod enums;
+mod float;
+mod fn_value;
+mod int;
+mod pointer_value;
+mod array;
+mod struct_value;
+mod global;
+mod phi;
+
+pub use enums::*;
+pub use float::*;
+pub use fn_value::*;
+pub use int::*;
+pub use pointer_value::*;
+pub use array::*;
+pub use struct_value::*;
+pub use global::*;
+pub use phi::*;
+
+pub trait AsValueRef {
+    fn as_value_ref(&self) -> LLVMValueRef;
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Values {
+    value: LLVMValueRef,
+}
+
+impl Values {
+    pub fn new(value: LLVMValueRef) -> Self {
+        Self { value }
+    }
+
+    pub fn into(self) -> LLVMValueRef {
+        self.value
+    }
+
+    pub fn kind(self) -> LLVMTypeKind {
+        unsafe { LLVMGetTypeKind(LLVMTypeOf(self.value)) }
+    }
+
+    fn get_type(self) -> LLVMTypeRef {
+        unsafe { LLVMTypeOf(self.value) }
+    }
+
+    pub fn is_void(self) -> bool {
+        matches!(self.kind(), LLVMTypeKind::LLVMVoidTypeKind)
+    }
+}

--- a/compiler/tahuc_codegen_llvm/src/llvm/values/phi.rs
+++ b/compiler/tahuc_codegen_llvm/src/llvm/values/phi.rs
@@ -1,0 +1,38 @@
+use tahuc_llvm::{core::LLVMAddIncoming, opaque::{LLVMBasicBlockRef, LLVMValueRef}};
+
+use crate::llvm::{AsValueRef, BasicBlock, BasicValue, Values};
+
+pub struct PhiValue {
+    value: Values,
+}
+
+impl PhiValue {
+    pub fn new(value: Values) -> Self {
+        Self { value }
+    }
+
+    pub fn as_value(self) -> Values {
+        self.value
+    }
+
+    pub fn as_value_ref(&self) -> LLVMValueRef {
+        self.value.into()
+    }
+
+    pub fn add_incoming(&mut self, incoming: Vec<(BasicValue, BasicBlock)>) {
+        let (mut value, mut blocks): (Vec<LLVMValueRef>, Vec<LLVMBasicBlockRef>) = 
+            incoming
+            .iter()
+            .map(|(v, bb)| (v.as_value_ref(), bb.as_block_ref()))
+            .collect();
+
+        unsafe {
+            LLVMAddIncoming(
+                self.as_value_ref(),
+                value.as_mut_ptr(),
+                blocks.as_mut_ptr(),
+                incoming.len() as u32,
+            );
+        }
+    }
+}

--- a/compiler/tahuc_codegen_llvm/src/llvm/values/pointer_value.rs
+++ b/compiler/tahuc_codegen_llvm/src/llvm/values/pointer_value.rs
@@ -1,0 +1,26 @@
+use tahuc_llvm::opaque::LLVMValueRef;
+
+use crate::llvm::Values;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct PointerValue {
+    value: Values,
+}
+
+impl PointerValue {
+    pub fn new(value: Values) -> Self {
+        Self { value }
+    }
+
+    pub fn into(&mut self) -> *mut Values {
+        &mut self.value
+    }
+
+    pub fn as_value_ref(self) -> LLVMValueRef {
+        self.value.into()
+    }
+
+    pub fn as_value(self) -> Values {
+        self.value
+    }
+}

--- a/compiler/tahuc_codegen_llvm/src/llvm/values/struct_value.rs
+++ b/compiler/tahuc_codegen_llvm/src/llvm/values/struct_value.rs
@@ -1,0 +1,22 @@
+use tahuc_llvm::opaque::LLVMValueRef;
+
+use crate::llvm::Values;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct StructValue {
+    value: Values,
+}
+
+impl StructValue {
+    pub fn new(value: Values) -> Self {
+        Self { value }
+    }
+
+    pub fn as_value_ref(self) -> LLVMValueRef {
+        self.value.into()
+    }
+
+    pub fn as_value(self) -> Values {
+        self.value
+    }
+}

--- a/compiler/tahuc_codegen_llvm/src/ty.rs
+++ b/compiler/tahuc_codegen_llvm/src/ty.rs
@@ -1,0 +1,65 @@
+use tahuc_mir::mir::ty::MirType;
+
+use crate::{codegen::Codegen, llvm::{FloatType, IntType, Type}};
+
+impl Codegen {
+    pub(crate) fn int_ty(&self, ty: &MirType) -> IntType {
+        match ty {
+            MirType::I8 | MirType::U8 => self.context.i8_ty(),
+            MirType::I16 | MirType::U16 => self.context.i16_ty(),
+            MirType::I32 | MirType::U32 => self.context.i32_ty(),
+            MirType::I64 | MirType::U64 => self.context.i64_ty(),
+            MirType::Isize | MirType::Usize => self.context.i32_ty(),
+            _ => panic!("Unsupported type {:?}", ty),
+        }
+    }
+
+    pub(crate) fn float_ty(&self, ty: &MirType) -> FloatType {
+        match ty {
+            MirType::F32 => self.context.f32_ty(),
+            MirType::F64 => self.context.f64_ty(),
+            _ => panic!("Unsupported type {:?}", ty),
+        }
+    }
+
+    pub(crate) fn ty_to_llvm(&mut self, ty: &MirType) -> Type {
+        match ty {
+            // primitive
+            MirType::I8 | MirType::U8 => self.context.i8_ty().as_ty(),
+            MirType::I16 | MirType::U16 => self.context.i16_ty().as_ty(),
+            MirType::I32 | MirType::U32 => self.context.i32_ty().as_ty(),
+            MirType::I64 | MirType::U64 => self.context.i64_ty().as_ty(),
+
+            MirType::F32 => self.context.f32_ty().as_ty(),
+            MirType::F64 => self.context.f64_ty().as_ty(),
+
+            MirType::Bool => self.context.bool_ty().as_ty(),
+            MirType::Char => self.context.i8_ty().as_ty(),
+            MirType::Unit => self.context.void_ty().as_ty(),
+
+            MirType::Pointer(_) => self.context.ptr_ty().as_ty(),
+
+            MirType::String => self.context.ptr_ty().as_ty(),
+            MirType::Array { ty, size } => {
+                let inner = self.ty_to_llvm(ty);
+                self.context.array_ty(inner, *size as u32).as_ty()
+            }
+            MirType::Struct { name, fields } => {
+                if let Some(ty) = self.struct_types.get(name) {
+                    return ty.as_ty();
+                }
+                let str = self.context.struct_ty(name);
+                self.struct_types.insert(name.clone(), str.clone());
+
+                let element_types: Vec<Type> =
+                    fields.iter().map(|f| self.ty_to_llvm(&f.1)).collect();
+                let packed = false;
+
+                str.set_body(element_types.as_slice(), packed);
+
+                str.as_ty()
+            }
+            _ => panic!("not implemented type {}", ty),
+        }
+    }
+}

--- a/compiler/tahuc_diagnostics/Cargo.toml
+++ b/compiler/tahuc_diagnostics/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-thiserror = "1.0"
 atty = "0.2.14"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/compiler/tahuc_driver/Cargo.toml
+++ b/compiler/tahuc_driver/Cargo.toml
@@ -12,4 +12,5 @@ tahuc_span = { path = "../tahuc_span" }
 tahuc_semantic = { path = "../tahuc_semantic" }
 tahuc_hir = { path = "../tahuc_hir" }
 tahuc_mir = { path = "../tahuc_mir" }
+tahuc_codegen_llvm = { path = "../tahuc_codegen_llvm" }
 tahuc_llvm = { path = "../tahuc_llvm" }

--- a/compiler/tahuc_llvm/src/core/builder.rs
+++ b/compiler/tahuc_llvm/src/core/builder.rs
@@ -49,6 +49,16 @@ unsafe extern "C" {
 
     pub unsafe fn LLVMBuildUnreachable(B: LLVMBuilderRef) -> LLVMValueRef;
 
+    // call
+    pub unsafe fn LLVMBuildCall2(
+        arg1: LLVMBuilderRef,
+        arg2: LLVMTypeRef,
+        Fn: LLVMValueRef,
+        Args: *mut LLVMValueRef,
+        NumArgs: std::ffi::c_uint,
+        Name: *const std::ffi::c_char,
+    ) -> LLVMValueRef;
+
     /// Add a case to a `switch` instruction
     pub unsafe fn LLVMAddCase(Switch: LLVMValueRef, OnVal: LLVMValueRef, Dest: LLVMBasicBlockRef);
 
@@ -111,11 +121,18 @@ unsafe extern "C" {
         Name: *const std::ffi::c_char,
     ) -> LLVMValueRef;
 
+    // phi instruction
     pub unsafe fn LLVMBuildPhi(
         arg1: LLVMBuilderRef,
         Ty: LLVMTypeRef,
         Name: *const std::ffi::c_char,
     ) -> LLVMValueRef;
+    pub unsafe fn LLVMAddIncoming(
+        PhiNode: LLVMValueRef,
+        IncomingValues: *mut LLVMValueRef,
+        IncomingBlocks: *mut LLVMBasicBlockRef,
+        Count: std::ffi::c_uint,
+    );
 
     pub unsafe fn LLVMBuildSelect(
         arg1: LLVMBuilderRef,
@@ -207,6 +224,22 @@ unsafe extern "C" {
         Name: *const std::ffi::c_char,
     ) -> LLVMValueRef;
 
+    // unary
+    pub unsafe fn LLVMBuildNeg(
+        arg1: LLVMBuilderRef,
+        V: LLVMValueRef,
+        Name: *const std::ffi::c_char,
+    ) -> LLVMValueRef;
+    pub unsafe fn LLVMBuildFNeg(
+        arg1: LLVMBuilderRef,
+        V: LLVMValueRef,
+        Name: *const std::ffi::c_char,
+    ) -> LLVMValueRef;
+    pub unsafe fn LLVMBuildNot(
+        arg1: LLVMBuilderRef,
+        V: LLVMValueRef,
+        Name: *const std::ffi::c_char,
+    ) -> LLVMValueRef;
 }
 
 // // Core->Pass managers

--- a/compiler/tahuc_llvm/src/core/core.rs
+++ b/compiler/tahuc_llvm/src/core/core.rs
@@ -12,7 +12,7 @@ unsafe extern "C" {
         ModuleID: *const std::ffi::c_char,
         C: LLVMContextRef,
     ) -> LLVMModuleRef;
-    pub unsafe fn LLVMModuleDispose(module: LLVMModuleRef);
+    pub unsafe fn LLVMDisposeModule(module: LLVMModuleRef);
 
     pub unsafe fn LLVMPrintModuleToFile(
         M: LLVMModuleRef,
@@ -36,4 +36,25 @@ unsafe extern "C" {
         N: std::ffi::c_ulonglong,
         SignExtend: LLVMBool,
     ) -> LLVMValueRef;
+
+    pub unsafe fn LLVMConstReal(RealTy: LLVMTypeRef, N: std::ffi::c_double) -> LLVMValueRef;
+    pub unsafe fn LLVMConstPointerNull(Ty: LLVMTypeRef) -> LLVMValueRef;
+    pub unsafe fn LLVMConstStringInContext(
+        C: LLVMContextRef,
+        Str: *const std::ffi::c_char,
+        Length: std::ffi::c_uint,
+        DontNullTerminate: LLVMBool,
+    ) -> LLVMValueRef;
+
+    pub unsafe fn LLVMAddGlobalInAddressSpace(
+        M: LLVMModuleRef,
+        Ty: LLVMTypeRef,
+        Name: *const std::ffi::c_char,
+        AddressSpace: std::ffi::c_uint,
+    ) -> LLVMValueRef;
+
+    // Function Value
+    pub unsafe fn LLVMCountParams(Fn: LLVMValueRef) -> std::ffi::c_uint;
+    pub unsafe fn LLVMGetParam(Fn: LLVMValueRef, Index: std::ffi::c_uint) -> LLVMValueRef;
+    pub unsafe fn LLVMGetNextParam(Arg: LLVMValueRef) -> LLVMValueRef;
 }

--- a/compiler/tahuc_llvm/src/core/ty.rs
+++ b/compiler/tahuc_llvm/src/core/ty.rs
@@ -1,4 +1,4 @@
-use crate::LLVMTypeKind;
+use crate::{LLVMLinkage, LLVMTypeKind, LLVMVisibility};
 
 use super::super::opaque::*;
 
@@ -12,6 +12,7 @@ unsafe extern "C" {
     pub unsafe fn LLVMInt64TypeInContext(C: LLVMContextRef) -> LLVMTypeRef;
     pub unsafe fn LLVMInt128TypeInContext(C: LLVMContextRef) -> LLVMTypeRef;
     pub unsafe fn LLVMIntTypeInContext(C: LLVMContextRef, NumBits: std::ffi::c_uint) -> LLVMTypeRef;
+    pub unsafe fn LLVMGetIntTypeWidth(IntegerTy: LLVMTypeRef) -> std::ffi::c_uint;
 
     // Core->Types->Floating-Point
     /**
@@ -58,6 +59,10 @@ unsafe extern "C" {
         IsVarArg: LLVMBool,
     ) -> LLVMTypeRef;
 
+    pub unsafe fn LLVMGetReturnType(FunctionTy: LLVMTypeRef) -> LLVMTypeRef;
+    pub unsafe fn LLVMGlobalGetValueType(Global: LLVMValueRef) -> LLVMTypeRef;
+    pub unsafe fn LLVMSetInitializer(GlobalVar: LLVMValueRef, ConstantVal: LLVMValueRef);
+
 
     // Core->Types->Struct
     pub unsafe fn LLVMStructCreateNamed(C: LLVMContextRef, Name: *const std::ffi::c_char) -> LLVMTypeRef;
@@ -84,4 +89,10 @@ unsafe extern "C" {
     // helper
     pub unsafe fn LLVMGetTypeKind(Ty: LLVMTypeRef) -> LLVMTypeKind;
     pub unsafe fn LLVMTypeOf(Val: LLVMValueRef) -> LLVMTypeRef;
+
+    pub unsafe fn LLVMSetLinkage(Global: LLVMValueRef, Linkage: LLVMLinkage);
+    pub unsafe fn LLVMSetVisibility(Global: LLVMValueRef, Viz: LLVMVisibility);
+
+    pub unsafe fn LLVMSetFunctionCallConv(Fn: LLVMValueRef, CC: std::ffi::c_uint);
+    pub unsafe fn LLVMSetInstructionCallConv(Instr: LLVMValueRef, CC: std::ffi::c_uint);
 }

--- a/compiler/tahuc_mir/src/builder/expression/call.rs
+++ b/compiler/tahuc_mir/src/builder/expression/call.rs
@@ -49,7 +49,7 @@ impl Builder {
             }
         }
 
-        self.call(Some(target), *callee, args, ty.to_mir_ty());
+        self.call(target, *callee, args, ty.to_mir_ty());
 
         MirOperand::Local(target)
     }

--- a/compiler/tahuc_mir/src/builder/instruction.rs
+++ b/compiler/tahuc_mir/src/builder/instruction.rs
@@ -72,7 +72,7 @@ impl Builder {
 
     pub(crate) fn call(
         &mut self,
-        target: Option<LocalId>,
+        target: LocalId,
         function: FunctionId,
         arguments: Vec<MirOperand>,
         ty: MirType,

--- a/compiler/tahuc_mir/src/mir/instruction.rs
+++ b/compiler/tahuc_mir/src/mir/instruction.rs
@@ -56,7 +56,7 @@ pub enum MirInstruction {
 
     /// Function Call
     Call {
-        target: Option<LocalId>,
+        target: LocalId,
         function: FunctionId,
         arguments: Vec<MirOperand>,
         ty: MirType,

--- a/compiler/tahuc_mir/src/mir/ty.rs
+++ b/compiler/tahuc_mir/src/mir/ty.rs
@@ -51,9 +51,9 @@ pub enum MirType {
     F32, F64,
     Bool,
     Char,
-    String,
     Unit,
     Null,
+    String,
     Pointer(Box<MirType>),
     Array {
         ty: Box<MirType>,
@@ -158,6 +158,30 @@ impl MirType {
     pub fn is_string(&self) -> bool {
         match self {
             MirType::String => true,
+            _ => false,
+        }
+    }
+
+    pub fn is_integer(self) -> bool {
+        match self {
+            MirType::I8 
+            | MirType::I16
+            | MirType::I32 
+            | MirType::I64
+            | MirType::Isize
+            | MirType::U8
+            | MirType::U16
+            | MirType::U32
+            | MirType::U64
+            | MirType::Usize => true,
+            _ => false,
+        }
+    }
+
+    pub fn is_float(self) -> bool {
+        match self {
+            MirType::F32 
+            | MirType::F64 => true,
             _ => false,
         }
     }

--- a/compiler/tahuc_mir/src/printer.rs
+++ b/compiler/tahuc_mir/src/printer.rs
@@ -252,17 +252,9 @@ impl<'a> MirPrinter<'a> {
                 )
             }
             MirInstruction::Call { target, function, arguments, .. } => {
-                let target_str = if let Some(target_id) = target {
-                    format!("%{} = ", target_id)
-                } else {
-                    String::new()
-                };
+                let target_str = format!("%{} = ", target);
 
-                let return_ty = if let Some(target_id) = target {
-                    self.get_local_type(*target_id).unwrap_or(&MirType::Unit)
-                } else {
-                    &MirType::Unit
-                };
+                let return_ty = self.get_local_type(*target).unwrap_or(&MirType::Unit);
 
                 let args_str = arguments
                     .iter()


### PR DESCRIPTION
- Added new type representations for arrays, booleans, floats, integers, pointers, structs, and void in the tahuc_codegen_llvm module.
- Introduced corresponding value representations for these types, including ArrayValue, BoolValue, FloatValue, IntValue, PointerValue, and StructValue.
- Enhanced the FunctionType struct to support function type creation from parameter types.
- Updated the LLVM core bindings to include new functions for building calls, handling phi nodes, and managing global values.
- Refactored the MIR type conversion logic to support new types and ensure proper type handling during code generation.
- Modified the printer to correctly format function call instructions with updated target handling.
- Removed unnecessary dependencies and streamlined the codebase for better maintainability.